### PR TITLE
rename some signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ Using special opcodes instead of the `tohost` mechanism is fine for all other te
         .WORD_CNT(`RAM_WORD_CNT),
         .MEM_FILE("INSERT THE PATH HERE")
     ) ramInst (
-        .a1(instrBusAddr),
-        .do1(instrBusData),
+        .a1(iAddr),
+        .do1(iRead),
 
-        .a2(dataBusAddr),
-        .di2(dataBusDataWrite),
-        .do2(dataBusDataRead),
-        .m2(writeMask),
-        .we2(dataBusWE),
-        .clk(sysClk)
+        .a2(dAddr),
+        .di2(dWrite),
+        .do2(dRead),
+        .m2(dMask),
+        .we2(dWE),
+        .clk(clk)
     );
    ```
    Now, the module `src/components/top.v`, including the CPU and RAM is ready for deploying onto the FPGA with the specified `.S` program.

--- a/rtl/components/controller.v
+++ b/rtl/components/controller.v
@@ -24,12 +24,12 @@ module controller (
     output reg [1:0]  loadSel,
     output reg [1:0]  maskSel,
     output reg        memToReg,
-    output reg        memWr,
+    output reg        memWE,
     output reg [2:0]  regDataSel,
-    output reg        regWr,
+    output reg        regWE,
     output reg        rs2ShiftSel,
     output reg        uext,
-    output reg        csrWr,
+    output reg        csrWE,
     output reg        mret,
     output reg        exception,
     output reg [30:0] excCode
@@ -67,12 +67,12 @@ module controller (
         loadSel     = funct3[1:0];
         maskSel     = funct3[1:0];
         memToReg    = 0;
-        memWr       = 0;
+        memWE       = 0;
         regDataSel  = 0;
-        regWr       = 0;
+        regWE       = 0;
         rs2ShiftSel = funct3[0];
         uext        = funct3[2];
-        csrWr       = 0;
+        csrWE       = 0;
         mret        = 0;
         exception   = 0;
         excCode     = 0;
@@ -80,7 +80,7 @@ module controller (
         casex (opcode[6:2]) // omit the lowest two bits of opcode - they are always 11
             5'b01100: begin // R-type
                 // set matching signals
-                regWr = 1;
+                regWE = 1;
 
                 case (funct3)
                     3'b000: ALUCtrl = {2'b00, funct7[5], ~funct7[5]}; // ADD or SUB
@@ -97,7 +97,7 @@ module controller (
             5'b00x00: begin // I-type without JALR
                 // set matching signals
                 ALUSrc2 = 2'b01;
-                regWr   = 1;
+                regWE   = 1;
 
                 if (opcode[4]) begin // immediate register-register
                     case (funct3)
@@ -120,12 +120,12 @@ module controller (
                 ALUToPC    = 1;
                 branch     = 1;
                 regDataSel = 3'b011;
-                regWr      = 1;
+                regWE      = 1;
             end
 
             5'b01000: begin // S-type
                 ALUSrc2 = 2'b01;
-                memWr  = 1;
+                memWE  = 1;
             end
 
             5'b11000: begin // B-type
@@ -162,13 +162,13 @@ module controller (
 
             5'b0x101: begin // U-type
                 regDataSel = opcode[5] ? 3'b010 : 3'b001;
-                regWr      = 1;
+                regWE      = 1;
             end
 
             5'b11011: begin // J-type
                 branch      = 1;
                 regDataSel  = 3'b011;
-                regWr       = 1;
+                regWE       = 1;
             end
 
             5'b00011: begin end // FENCE or Zifencei standard extension
@@ -206,22 +206,22 @@ module controller (
                     3'b001: begin // CSRRW
                         ALUCtrl    = 0;
                         regDataSel = 3'b100;
-                        regWr      = 1;
-                        csrWr      = 1;
+                        regWE      = 1;
+                        csrWE      = 1;
                     end
                     3'b010: begin // CSRRS
                         ALUCtrl    = 4'b0101;
                         ALUSrc2    = 2'b10;
                         regDataSel = 3'b100;
-                        regWr      = 1;
-                        csrWr      = rs1 != 0;
+                        regWE      = 1;
+                        csrWE      = rs1 != 0;
                     end
                     3'b011: begin // CSRRC
                         ALUCtrl    = 4'b0100;
                         ALUSrc2    = 2'b10;
                         regDataSel = 3'b100;
-                        regWr      = 1;
-                        csrWr      = rs1 != 0;
+                        regWE      = 1;
+                        csrWE      = rs1 != 0;
                     end
                     3'b100: begin
                        `ILLEGAL_INSTR_HANDLER 
@@ -231,24 +231,24 @@ module controller (
                         ALUSrc1    = 1;
                         ALUSrc2    = 2'b10;
                         regDataSel = 3'b100;
-                        regWr      = 1;
-                        csrWr      = 1;
+                        regWE      = 1;
+                        csrWE      = 1;
                     end
                     3'b110: begin // CSRRSI
                         ALUCtrl    = 4'b0101;
                         ALUSrc1    = 1;
                         ALUSrc2    = 2'b10;
                         regDataSel = 3'b100;
-                        regWr      = 1;
-                        csrWr      = uimm != 0;
+                        regWE      = 1;
+                        csrWE      = uimm != 0;
                     end
                     3'b111: begin // CSRRCI
                         ALUCtrl    = 4'b0100;
                         ALUSrc1    = 1;
                         ALUSrc2    = 2'b10;
                         regDataSel = 3'b100;
-                        regWr      = 1;
-                        csrWr      = uimm != 0;
+                        regWE      = 1;
+                        csrWE      = uimm != 0;
                     end
                 endcase
             end

--- a/rtl/components/cpu.v
+++ b/rtl/components/cpu.v
@@ -14,17 +14,17 @@ module cpu (
     input             clk,
     input             reset,
     input      [31:0] instruction,
-    input      [31:0] memReadData,
-    output            memWr,  // write enable to data memory
-    output     [3:0]  wrMask,
+    input      [31:0] memRdData,
+    output            memWE,  // write enable to data memory
+    output     [3:0]  memMask,
     output reg [31:0] PC,
     output     [31:0] memAddr,
-    output     [31:0] memWriteData
+    output     [31:0] memWrData
 );
 
     // wire/reg declarations
-    wire ALUZero, ALUToPC, memToReg, regWr, rs2ShiftSel,
-         uext, csrWr, mcauseWr, branch;
+    wire ALUZero, ALUToPC, memToReg, regWE, rs2ShiftSel,
+         uext, csrWE, branch;
     wire [1:0] loadSel, maskSel, ALUSrc1, ALUSrc2;
     wire [2:0] regDataSel;
     wire [3:0] ALUCtrl;
@@ -62,12 +62,12 @@ module cpu (
         .loadSel(loadSel),
         .maskSel(maskSel),
         .memToReg(memToReg),
-        .memWr(memWr),
+        .memWE(memWE),
         .regDataSel(regDataSel),
-        .regWr(regWr),
+        .regWE(regWE),
         .rs2ShiftSel(rs2ShiftSel),
         .uext(uext),
-        .csrWr(csrWr),
+        .csrWE(csrWE),
         .mret(mret),
         .exception(exception),
         .excCode(excCode)
@@ -95,7 +95,7 @@ module cpu (
         .a2(instruction[24:20]),
         .a3(instruction[11:7]),
         .di3(regRes),
-        .we3(regWr),
+        .we3(regWE),
         .clk(clk),
         .rd1(rs1),
         .rd2(rs2)
@@ -111,7 +111,7 @@ module cpu (
     csr csrInst (
         .reset(reset),
         .clk(clk),
-        .we(csrWr),
+        .we(csrWE),
         .a(instruction[31:20]),
         .di(ALURes),
         .do(csrOut),
@@ -148,10 +148,10 @@ module cpu (
     assign branchTarget     = ALUToPC ? ALURes : immPC;
     assign src1             = ALUSrc1 ? imm : rs1;
     assign rs2Shift         = rs2ShiftSel ? {ALURes[1], 4'b0} : {ALURes[1:0], 3'b0};
-    assign memWriteData     = rs2 << rs2Shift;
+    assign memWrData     = rs2 << rs2Shift;
     assign memAddr          = ALURes;
-    assign wrMask           = mask << ALURes[1:0];
-    assign dataLH           = ALURes[1] ? memReadData[31:16] : memReadData[15:0];
+    assign memMask           = mask << ALURes[1:0];
+    assign dataLH           = ALURes[1] ? memRdData[31:16] : memRdData[15:0];
     assign regRes           = memToReg ? memData : regData;
     assign branchMretTarget = mret ? mepcOut : branchTarget;
     assign nextPC           = branch | mret ? branchMretTarget : PC4;
@@ -208,10 +208,10 @@ module cpu (
     // dataLB mux
     always @(*) begin
         case (ALURes[1:0])
-            2'b00:   dataLB = memReadData[7:0];
-            2'b01:   dataLB = memReadData[15:8];
-            2'b10:   dataLB = memReadData[23:16];
-            default: dataLB = memReadData[31:24];
+            2'b00:   dataLB = memRdData[7:0];
+            2'b01:   dataLB = memRdData[15:8];
+            2'b10:   dataLB = memRdData[23:16];
+            default: dataLB = memRdData[31:24];
         endcase
     end
 
@@ -220,7 +220,7 @@ module cpu (
         case (loadSel)
             2'b00:   memData = dataExtLB;
             2'b01:   memData = dataExtLH;
-            default: memData = memReadData;
+            default: memData = memRdData;
         endcase
     end
 

--- a/rtl/components/top.v
+++ b/rtl/components/top.v
@@ -13,34 +13,34 @@
 `include "rtl/constants.vh"
 
 module top (
-    input sysClk,
-    input sysRes
+    input clk,
+    input reset
 );
 
-    wire dataBusWE;
-    wire [3:0] writeMask;
-    wire [31:0] instrBusAddr, instrBusData, dataBusAddr, dataBusDataWrite,
-                dataBusDataRead;
+    wire dWE;
+    wire [3:0] dMask;
+    wire [31:0] iAddr, iRead, dAddr, dWrite,
+                dRead;
     
     `ifdef SPLIT_MEMORY
         instructionMemory #(
             .WORD_CNT(`INSTR_MEM_WORD_CNT),
             .MEM_FILE("")
         ) instrMemInst (
-            .a(instrBusAddr),
-            .d(instrBusData)
+            .a(iAddr),
+            .d(iRead)
         );
 
         dataMemory #(
             .WORD_CNT(`DATA_MEM_WORD_CNT),
             .MEM_FILE("")
         ) dataMemInst (
-            .clk(sysClk),
-            .we(dataBusWE),
-            .mask(writeMask),
-            .a(dataBusAddr),
-            .di(dataBusDataWrite),
-            .do(dataBusDataRead)
+            .clk(clk),
+            .we(dWE),
+            .mask(dMask),
+            .a(dAddr),
+            .di(dWrite),
+            .do(dRead)
         );
 
     `else
@@ -48,30 +48,30 @@ module top (
             .WORD_CNT(`RAM_WORD_CNT),
             .MEM_FILE("")
         ) ramInst (
-            .a1(instrBusAddr),
-            .do1(instrBusData),
+            .a1(iAddr),
+            .do1(iRead),
 
-            .a2(dataBusAddr),
-            .di2(dataBusDataWrite),
-            .do2(dataBusDataRead),
-            .m2(writeMask),
-            .we2(dataBusWE),
-            .clk(sysClk)
+            .a2(dAddr),
+            .di2(dWrite),
+            .do2(dRead),
+            .m2(dMask),
+            .we2(dWE),
+            .clk(clk)
         );
     `endif // SPLIT_MEMORY
 
     cpu cpuInst (
-        .clk(sysClk),
-        .reset(sysRes),
+        .clk(clk),
+        .reset(reset),
 
-        .instruction(instrBusData),
-        .PC(instrBusAddr),
+        .instruction(iRead),
+        .PC(iAddr),
 
-        .memAddr(dataBusAddr),
-        .memReadData(dataBusDataRead),
-        .memWriteData(dataBusDataWrite),
-        .memWr(dataBusWE),
-        .wrMask(writeMask)
+        .memAddr(dAddr),
+        .memRdData(dRead),
+        .memWrData(dWrite),
+        .memWE(dWE),
+        .memMask(dMask)
     );
 
 endmodule

--- a/rtl/top/ledDebugTop.v
+++ b/rtl/top/ledDebugTop.v
@@ -5,26 +5,26 @@
 `include "rtl/primitives/synchronizer.v"
 
 module ledDebugTop(
-    input sysClk,
-    input sysRes,
+    input clk,
+    input reset,
     output [31:16] PCdebug
 );
 
-    wire reset;
+    wire syncReset;
 
     // synchronize reset signal
     synchronizer #(
         .LEN(1),
         .STAGES(2)
     ) resetSync (
-        .clk(sysClk),
-        .dataIn(sysRes),
-        .dataOut(reset)
+        .clk(clk),
+        .dataIn(reset),
+        .dataOut(syncReset)
     );
 
     top topInst(
-        .sysClk(sysClk),
-        .sysRes(reset)
+        .clk(clk),
+        .reset(syncReset)
     );
     
     assign PCdebug = topInst.cpuInst.registerFile32Inst.rf[1][31:16];

--- a/synth/basys3/constraints.xdc
+++ b/synth/basys3/constraints.xdc
@@ -1,7 +1,7 @@
-set_property PACKAGE_PIN W5 [get_ports sysClk]
-set_property PACKAGE_PIN U18 [get_ports sysRes]
-set_property IOSTANDARD LVCMOS33 [get_ports sysClk]
-set_property IOSTANDARD LVCMOS33 [get_ports sysRes]
+set_property PACKAGE_PIN W5 [get_ports clk]
+set_property PACKAGE_PIN U18 [get_ports reset]
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports reset]
 
 
 set_property IOSTANDARD LVCMOS33 [get_ports {PCdebug[31]}]
@@ -36,5 +36,5 @@ set_property PACKAGE_PIN V19 [get_ports {PCdebug[19]}]
 set_property PACKAGE_PIN U19 [get_ports {PCdebug[18]}]
 set_property PACKAGE_PIN E19 [get_ports {PCdebug[17]}]
 set_property PACKAGE_PIN U16 [get_ports {PCdebug[16]}]
-create_clock -period 10.000 -name CLK -waveform {0.000 5.000} [get_ports sysClk]
+create_clock -period 10.000 -name CLK -waveform {0.000 5.000} [get_ports clk]
 

--- a/tests/riscvTopTest.v
+++ b/tests/riscvTopTest.v
@@ -16,8 +16,8 @@ module topTest();
     integer pcValuesLogPtr = 0;
 
     top dut (
-        .sysClk(clk),
-        .sysRes(reset)
+        .clk(clk),
+        .reset(reset)
     );
 
     initial begin
@@ -59,7 +59,7 @@ module topTest();
         //     "ALUZero: %b\n", dut.cpuInst.ALUZero,
         //     "ALUSrc1: %b\n", dut.cpuInst.ALUSrc1,
         //     "ALUSrc2: %b\n", dut.cpuInst.ALUSrc2,
-        //     "regWr: %b\n", dut.cpuInst.regWr,
+        //     "regWE: %b\n", dut.cpuInst.regWE,
         //     "regDataSel: %b\n", dut.cpuInst.regDataSel,
         //     "memToReg: %b", dut.cpuInst.memToReg
         // );
@@ -77,12 +77,12 @@ module topTest();
         pcValuesLog[pcValuesLogPtr] = dut.cpuInst.PC;
         pcValuesLogPtr++;
 
-        if (dut.instrBusData === `OPCODE_PASS) begin
+        if (dut.iRead === `OPCODE_PASS) begin
             $display(`ASSERT_SUCCESS);
             $finish;
         end
 
-        if (dut.instrBusData === `OPCODE_FAIL) begin
+        if (dut.iRead === `OPCODE_FAIL) begin
             $display(`ASSERT_FAIL);
             
             $display("Last PC values dump:");


### PR DESCRIPTION
A lot of signals in the RTL source code didn't match the signals in the schematics. Because of that, debugging was harder and confusing. Now, all signals in the source code match the signals in all schematics.