### PR TITLE
Fixed empty flag FIFO error

### DIFF
--- a/rtl/primitives/fifo.v
+++ b/rtl/primitives/fifo.v
@@ -32,8 +32,8 @@ always @( posedge clk ) begin : fifo_operations
             memory[backPointer] <= di;
             backPointer         <= backPointerInc;
 
+            empty <= 0;
             if ( !re ) begin
-                empty <= 0;
                 full  <= ( frontPointer == backPointerInc ) ? 1'b1 : 1'b0;
             end
         end


### PR DESCRIPTION
This fixes a bug in FIFO primitive where empty flag is not set correctly when reading and writing at the same time.